### PR TITLE
Fix for Error 500 on Sails Aggregates

### DIFF
--- a/api/controllers/UserLoginController.js
+++ b/api/controllers/UserLoginController.js
@@ -34,8 +34,8 @@ module.exports = _.merge(_.cloneDeep(require('../base/Controller')), {
      */
     var fetchStatistics = function fetchStatistics() {
       return sails.models['userlogin']
-        .find({sum: 'count'})
-        .groupBy(groupBy)
+          .find().sum('count')
+          .groupBy(groupBy)
       ;
     };
 


### PR DESCRIPTION
I ran into this issue on the admin loginHistory.

Received error:

error: Sending 500 ("Server Error") response:
 TypeError: sum.forEach is not a function
    at Aggregate.sum (/Users/brian/Development/3rdParty/angular-sailsjs-boilerplate/backend/node_modules/sails-disk/lib/aggregates.js:109:7)

I noticed a different way of performing this function on a closed issue here: 
https://github.com/balderdashy/waterline/issues/61

That resolved the issue.
